### PR TITLE
chore(cargo): update `homepage` to `repository`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "lambda_utils"
 version = "0.1.5"
 edition = "2021"
-homepage = "https://github.com/MadebyAe/lambda-utils"
+repository = "https://github.com/MadebyAe/lambda-utils"
 description = "Lambda Utils for AWS Rust Lambda"
 authors = ["Ae <hi@angel-estrada.com>"]
 keywords = ["aws", "lambda", "serverless", "rust"]


### PR DESCRIPTION
Change `homepage` key to instead use the [repository](https://rust-digger.code-maven.com/about-repository) key for correctly labeling/pointing to the GitHub repo.

This makes location of the source code easier to see Crates.io. 🙂